### PR TITLE
D) Pandas – Operaciones avanzadas en DataFrames

### DIFF
--- a/2. Datasheet de NumPy y Pandas.md
+++ b/2. Datasheet de NumPy y Pandas.md
@@ -310,3 +310,47 @@ Las ramas que son 4 (A, B, C y D) están propuestas por la actividad como:
 <p align="center">
 <img width="659" height="364" alt="cg6" src="https://github.com/user-attachments/assets/fc4eee0a-0bf0-4728-bdcf-06a59c4bc2a5" />
 </p>
+
+- **df.isnull():** El método df.isnull() genera un DataFrame que tiene las mismas dimensiones, donde cada celda muestra True si el valor es nulo (NaN) y False si contiene un dato valido, esta tiene una utilidad considerable para identificar valores que faltan antes de proceder a su limpieza o sustitución. Con esto, la salida marca True a las ubicaciones de los valores que faltan (NaN), esto se puede utilizar como punto de partida junto a métodos como df.dropna() o df.fillna(). 
+  **Ejemplo:**
+<p align="center">
+<img width="404" height="450" alt="cg7" src="https://github.com/user-attachments/assets/3f1a92bb-d729-48a5-b4f6-8cc4f4838f92" />
+</p>
+
+- **df.isnull()sum():** La función df.isnull().sum() une dos operaciones: en primer lugar, detecta los valores nulos con isnull(), y después cuenta cuantos True hay en cada columna para proporcionar un recuento de los valores ausentes en cada columna, lo que es bastante útil para evaluar de manera rápida la calidad de los datos. Con este ejemplo, el resultado indica que la columna edad presenta 1 valor nulo, y la columna nota también tiene 1 valor nulo, mientras que la columna nombre no presenta valores faltantes.
+  **Ejemplo:**
+<p align="center">
+<img width="529" height="419" alt="cg8" src="https://github.com/user-attachments/assets/c1d89d95-ce7b-4299-813d-1cd9161bd58d" />
+</p>
+
+- **df.join(df2):** El comando df.join(df2) se emplea para conectar dos DataFrames de forma fácil, generalmente usando sus índices como base, resulta practico cuando poseemos datos adicionales en otro DataFrame y deseamos incorporarlos como columnas nuevas. A diferencia de merge, que habitualmente utiliza columnas como claves, se apoya directamente en el índice (aunque es posible modificarlo). Con este ejemplo, df2 se combina con df1 utilizando el índice (0,1,2,3) como referencia, y se incluye la columna nota.
+  **Ejemplo:**
+<p align="center">
+<img width="287" height="504" alt="cg9" src="https://github.com/user-attachments/assets/b28594a0-dec0-49ea-aba0-6d4312c7e00f" />
+</p>
+
+- **pd.concat([df1, df2]):** Esta función facilita la combinación de DataFrames, ya sea en filas (que es la opción predeterminada) o en columnas, resulta muy práctico para agrupar múltiples conjuntos de datos que siguen la misma estructura, o para incorporar información adicional a un DataFrame que ya existe. Con este caso, los dos DataFrames se han combinado uno debajo del otro, los índices se mantienen y para resetearlos se podría usar ignore_index=True dentro de concat().
+  **Ejemplo:**
+<p align="center">
+<img width="319" height="522" alt="cg10" src="https://github.com/user-attachments/assets/231d6ea0-303c-4f9d-935b-2d329c121f57" />
+</p>
+
+- **df.drop_duplicates():** Este método elimina las filas que se repiten en un DataFrame, conservando solamente la primera instancia de cada fila duplicada, es útil cuando hay datos redundantes y deseamos conservar únicamente la información única. En este ejemplo, se han eliminado las filas duplicadas de Ana y Luis, quedado solo la primera instancia de cada uno.
+  **Ejemplo:**
+<p align="center">
+<img width="470" height="442" alt="cg11" src="https://github.com/user-attachments/assets/ec42e0b6-483a-4a49-9f30-3ba9a14387eb" />
+</p>
+
+- **df.rename(colums={"old":"new"}):** El comando df.rename() se utiliza para cambiar el nombre de columnas o índices en un DataFrame, emplea el argumento columns, podemos indicar un diccionario en el que las claves (old) corresponden a los nombres existentes y los valores (new) son los nombres que queremos establecer. En este caso, el encabezado de la columna “nombre” se ha modificado a “Nombre_Completo”, aunque los datos continúan siendo los mismos.
+  **Ejemplo:**
+<p align="center">
+<img width="517" height="414" alt="cg12" src="https://github.com/user-attachments/assets/ead5c6ac-13d5-4ae0-ae75-e28a2887bf73" />
+</p>
+
+- **df.to_excel(“archivo.xlsx”, index=false):** El comando to_excel() permite almacenar la información de un DataFrame en un archivo de tipo Excel (.xlsx), la opción index=False se usa para prevenir que la columna de índices de Pandas se incluya en el archivo. En este ejemplo, se crea un archivo denominado inventario.xlsx que se podrá abrir con Excel, Google Sheets, etc.
+  **Ejemplo:**
+<p align="center">
+<img width="611" height="344" alt="cg13" src="https://github.com/user-attachments/assets/d80d6eac-24f1-41fd-a515-95c55ad94fb0" />
+</p>
+
+---

--- a/2. Datasheet de NumPy y Pandas.md
+++ b/2. Datasheet de NumPy y Pandas.md
@@ -16,7 +16,7 @@ Las ramas que son 4 (A, B, C y D) están propuestas por la actividad como:
 - **D)** Pandas avanzado
 
 ---  
-**A)** NumPy - Creación y manipulación de arreglos
+## **A) NumPy - Creación y manipulación de arreglos**
 
 - **array:** Este comando se utiliza para la creación de listas o tuplas para luego devolver los valores referentes a lo puesto en el código. Las dimensiones dependen de cuántos valores o tipos de datos se añadan al arreglo creado, tal como lo demuestra la siguiente imagen.  
 
@@ -114,7 +114,7 @@ Las ramas que son 4 (A, B, C y D) están propuestas por la actividad como:
 
 ---  
 
-B) NumPy – Operaciones estadísticas y funciones avanzadas
+## **B) NumPy – Operaciones estadísticas y funciones avanzadas**
 
 - **np.mean():** La función del comando es calcular el promedio de los elementos dentro de un array, sumando todos los valores y dividiendo el resultado entre el total de elementos del array
   **Ejemplo:**
@@ -184,7 +184,7 @@ B) NumPy – Operaciones estadísticas y funciones avanzadas
 
 ---
 
-**C)** Pandas – Creación y manipulación de DataFrames y Series  
+## **C) Pandas – Creación y manipulación de DataFrames y Series**  
 
 - **pd.Series():** Este comando se utiliza para generar una Serie, que es una estructura de datos unidimensional (similar a una lista o vector) que guarda datos junto con un índice que identifica cada elemento. A diferencia de una lista de Python, una Serie en Pandas cuenta con numerosas funciones extras como cálculos matemáticos, filtros y estadística. Además de ser compatible con otras estructuras como los Dataframes. En este ejemplo, la Serie (la cual es nombrada “Edades”) incluye los números: 10,20,30,40 y cada uno esta vinculado a un índice que se genera automáticamente: 0,1,2,3. Transformándolo en un recurso muy práctico para manejar información de una única columna en forma organizada.
   **Ejemplo:**
@@ -205,68 +205,108 @@ B) NumPy – Operaciones estadísticas y funciones avanzadas
 <img width="665" height="232" alt="gc3" src="https://github.com/user-attachments/assets/291cd2ac-e6bb-4d39-a3e4-c642af3529af" />
 </p>
 
-- **df[“columna”]** En un DataFrame, se puede elegir cada columna de manera individual utilizando esta notación, lo cual arroja una Serie que contiene los valores de la columna seleccionada. Si deseamos obtener varias columnas simultáneamente, se pueden pasar los nombres en una lista, como df[[“col1”, “col2”]]. Esto es bastante practico cuando necesitamos enfocarnos únicamente en ciertas variables dentro del conjunto de datos. En este ejemplo, la primera selección proporciona una Serie con los nombres, mientras que la segunda entrega un nuevo DataFrame que incluye dos columnas: Nombre y Edad.
+- **df[“columna”]:** En un DataFrame, se puede elegir cada columna de manera individual utilizando esta notación, lo cual arroja una Serie que contiene los valores de la columna seleccionada. Si deseamos obtener varias columnas simultáneamente, se pueden pasar los nombres en una lista, como df[[“col1”, “col2”]]. Esto es bastante practico cuando necesitamos enfocarnos únicamente en ciertas variables dentro del conjunto de datos. En este ejemplo, la primera selección proporciona una Serie con los nombres, mientras que la segunda entrega un nuevo DataFrame que incluye dos columnas: Nombre y Edad.
   **Ejemplo:**
 <p align="center">
 <img width="390" height="454" alt="gc4" src="https://github.com/user-attachments/assets/7d4b89f6-6d93-44b2-bcaa-8c13102750dc" />
 </p>
 
-- **df.dtypes** Este atributo permite determinar el tipo de dato correspondiente a cada columna dentro de un DataFrame, lo que resulta fundamental ya que en el análisis de datos es esencial verificar que las columnas posean el tipo adecuado (por ejemplo: números como int64 o float64, texto como object, fechas como datetime64, etc.), reconocer los tipos de datos nos proporciona información sobre las operaciones que se pueden realizar en cada columna. En este caso, Pandas detecta automáticamente que Nombre es un texto (object), Edad es un numero entero (int64), Salario es un numero flotante (float64) y Activo es un valor booleano (bool). Esto facilita la ejecución correcta de operaciones de acuerdo con el tipo de datos. 
+- **df.dtypes:** Este atributo permite determinar el tipo de dato correspondiente a cada columna dentro de un DataFrame, lo que resulta fundamental ya que en el análisis de datos es esencial verificar que las columnas posean el tipo adecuado (por ejemplo: números como int64 o float64, texto como object, fechas como datetime64, etc.), reconocer los tipos de datos nos proporciona información sobre las operaciones que se pueden realizar en cada columna. En este caso, Pandas detecta automáticamente que Nombre es un texto (object), Edad es un numero entero (int64), Salario es un numero flotante (float64) y Activo es un valor booleano (bool). Esto facilita la ejecución correcta de operaciones de acuerdo con el tipo de datos. 
   **Ejemplo:**
 <p align="center">
 <img width="395" height="294" alt="gc5" src="https://github.com/user-attachments/assets/ff208b6d-36c8-40d1-90c7-f70f29fbc205" />
 </p>
 
-- **df.head** El método presenta las filas iniciales de un DataFrame (por defecto 5). Es practico para obtener una visión rápida de la apariencia de la tabla tras su carga o creacion, y para confirmar que los datos se han importado de manera adecuada. Se puede especificar un numero como parámetro para mostrar un mayor o menor numero de filas, por ejemplo, df.head(10) para visualizar las primeras diez. Aquí observamos las cinco filas iniciales del anteriormente usado dataset iris, lo que nos facilita comprender rápidamente la organización de la información (columnas y valores). 
+- **df.head:** El método presenta las filas iniciales de un DataFrame (por defecto 5). Es practico para obtener una visión rápida de la apariencia de la tabla tras su carga o creacion, y para confirmar que los datos se han importado de manera adecuada. Se puede especificar un numero como parámetro para mostrar un mayor o menor numero de filas, por ejemplo, df.head(10) para visualizar las primeras diez. Aquí observamos las cinco filas iniciales del anteriormente usado dataset iris, lo que nos facilita comprender rápidamente la organización de la información (columnas y valores). 
   **Ejemplo:**
 <p align="center">
 <img width="655" height="220" alt="gc6" src="https://github.com/user-attachments/assets/d245b777-5b85-489d-b9bb-3f1fb6daf5b9" />
 </p>
 
-- **df.info** Este método proporciona un panorama general del DataFrame, indicando cuantas filas y columnas contiene, cuantos valores no nulos hay en cada columna, su tipo de datos y la memoria que ocupa, resultando bastante útil al comenzar un análisis, ya que permite identificar si faltan datos, que tipos de variables hay y la dimensión de la tabla. En esta situación, observamos que el conjunto de datos consta de 150 filas y 5 columnas, de las cuales 4 son numéricas (float64) y 1 es de tipo texto (object), que además confirma que no se encuentran valores nulos.
+- **df.info:** Este método proporciona un panorama general del DataFrame, indicando cuantas filas y columnas contiene, cuantos valores no nulos hay en cada columna, su tipo de datos y la memoria que ocupa, resultando bastante útil al comenzar un análisis, ya que permite identificar si faltan datos, que tipos de variables hay y la dimensión de la tabla. En esta situación, observamos que el conjunto de datos consta de 150 filas y 5 columnas, de las cuales 4 son numéricas (float64) y 1 es de tipo texto (object), que además confirma que no se encuentran valores nulos.
   **Ejemplo:**
 <p align="center">
 <img width="652" height="332" alt="gc7" src="https://github.com/user-attachments/assets/3c4bf64c-5ede-40a6-9606-abbdffa9d164" />
 </p>
 
-- **df.describe()** Este método crea un resumen estadístico de las columnas numéricas en un DataFrame, presentando métricas como el numero de valores (count), la media (mean), la desviación estándar (std), el valor mínimo (min), los cuartiles (25%, 50%, 75%) y el máximo (max). Esto ofrece una visión rápida de la distribución de los datos y ayuda a identificar valores anómalos o rangos. Aquí podemos notar que, en este ejemplo, la longitud media del sépalo es 5.84, y varia de un valor mínimo de 4.3 a uno máximo de 7. 9..
+- **df.describe():** Este método crea un resumen estadístico de las columnas numéricas en un DataFrame, presentando métricas como el numero de valores (count), la media (mean), la desviación estándar (std), el valor mínimo (min), los cuartiles (25%, 50%, 75%) y el máximo (max). Esto ofrece una visión rápida de la distribución de los datos y ayuda a identificar valores anómalos o rangos. Aquí podemos notar que, en este ejemplo, la longitud media del sépalo es 5.84, y varia de un valor mínimo de 4.3 a uno máximo de 7. 9..
   **Ejemplo:**
 <p align="center">
 <img width="657" height="269" alt="gc8" src="https://github.com/user-attachments/assets/1aa7ccee-c9bc-461a-a929-08d84b54cf57" />
 </p>
 
-- **df.shape** Este comando proporciona una tupla que contiene dos números: la cantidad de filas y la cantidad de columnas en un DataFrame que resulta muy practico para obtener de manera rápida las dimensiones del conjunto de datos y confirmar si cuenta con el numero anticipado de registros y valores. Esto indica que el DataFrame comprende 150 filas (observaciones) y 5 columnas (variables) siendo un método eficiente para comprobar el tamaño de la información antes de realizar un análisis mas detallado.
+- **df.shape:** Este comando proporciona una tupla que contiene dos números: la cantidad de filas y la cantidad de columnas en un DataFrame que resulta muy practico para obtener de manera rápida las dimensiones del conjunto de datos y confirmar si cuenta con el numero anticipado de registros y valores. Esto indica que el DataFrame comprende 150 filas (observaciones) y 5 columnas (variables) siendo un método eficiente para comprobar el tamaño de la información antes de realizar un análisis mas detallado.
   **Ejemplo:**
 <p align="center">
 <img width="660" height="129" alt="gc9" src="https://github.com/user-attachments/assets/8bf9fa2f-4703-41ba-bdcf-6181c054f967" />
 </p>
 
-- **df.tail** Este proporciona las filas finales de un DataFrame. Por defecto, presenta 5 filas, aunque se puede indicar una cantidad diferente al pasarla como argumento lo que hace de la instrucción es practica para inspeccionar de manera rápida el final de un conjunto de datos y verificar la organización de los registros más recientes o los últimos que se han añadido. En este ejemplo, el comando nos presenta las ultimas 5 entradas del conjunto de datos de flores iris, todas de la especie virginica.
+- **df.tail:** Este proporciona las filas finales de un DataFrame. Por defecto, presenta 5 filas, aunque se puede indicar una cantidad diferente al pasarla como argumento lo que hace de la instrucción es practica para inspeccionar de manera rápida el final de un conjunto de datos y verificar la organización de los registros más recientes o los últimos que se han añadido. En este ejemplo, el comando nos presenta las ultimas 5 entradas del conjunto de datos de flores iris, todas de la especie virginica.
   **Ejemplo:**
 <p align="center">
 <img width="657" height="214" alt="gc10" src="https://github.com/user-attachments/assets/648b381f-1229-431e-8869-0a1a6ddf0806" />
 </p>
 
-- **df.iloc[ ]/df.loc[ ]** Ambas tecnicas permiten acceder a líneas y columnas determinadas de un DataFrame, aunque operan de manera distinta, el iloc selecciona basada en índices numéricos (posición) y loc selecciona utilizando etiquetas (nombres de filas o columnas). En este ejemplo, con iloc se logra acceder a la fila inicial (0) y a las dos primeras columnas. Con loc se elige de manera especifica por los nombres de las columnas (sepal_length y species). Estos son métodos fundamentales al manejar subconjuntos de datos.
+- **df.iloc[ ]/df.loc[ ]:** Ambas tecnicas permiten acceder a líneas y columnas determinadas de un DataFrame, aunque operan de manera distinta, el iloc selecciona basada en índices numéricos (posición) y loc selecciona utilizando etiquetas (nombres de filas o columnas). En este ejemplo, con iloc se logra acceder a la fila inicial (0) y a las dos primeras columnas. Con loc se elige de manera especifica por los nombres de las columnas (sepal_length y species). Estos son métodos fundamentales al manejar subconjuntos de datos.
   **Ejemplo:**
 <p align="center">
 <img width="777" height="315" alt="gc11" src="https://github.com/user-attachments/assets/ce39ccd3-65b8-41c2-8d53-a9ec2db2f574" />
 </p>
 
-- **df.drop** El comando se utiliza para eliminar elementos dentro de un DataFrame, ya sea filas (a través de su indice) o columnas (mediante su nombre) utilizando principalmente el parámetro axis: =0 sirve para eliminar filas, =1 elimina columnas. En este caso se emplea df.drop (“species”, axis=1) para retirar la columna species. Mientras que, se utiliza el df.drop(0, axis=0) para eliminar la fila inicial (índice 0). Resultando muy útil cuando se desea depurar un dataset y deshacerse de variables no relevantes o filas problemáticas. 
+- **df.drop:** El comando se utiliza para eliminar elementos dentro de un DataFrame, ya sea filas (a través de su indice) o columnas (mediante su nombre) utilizando principalmente el parámetro axis: =0 sirve para eliminar filas, =1 elimina columnas. En este caso se emplea df.drop (“species”, axis=1) para retirar la columna species. Mientras que, se utiliza el df.drop(0, axis=0) para eliminar la fila inicial (índice 0). Resultando muy útil cuando se desea depurar un dataset y deshacerse de variables no relevantes o filas problemáticas. 
   **Ejemplo:**
 <p align="center">
 <img width="658" height="447" alt="gc12" src="https://github.com/user-attachments/assets/b8d078b6-bf85-4c47-a9c3-31b7d4fbafa4" />
 </p>
 
-- **df.sort_values(“columna”)** Este método facilita la organización de un DataFrame según una columna particular o múltiples, siendo organizados de manera ascendente (ascending=True, que es el valor predeterminado) o de forma descendente (ascending=False). En este ejemplo, ascending=True (valor por defecto) es el DataFrame que se clasifica de menor a mayor. Ascending=False es el DataFrame que se organiza de mayor a menor, siendo bastante útil para estudiar y clasificar datos. 
+- **df.sort_values(“columna”):** Este método facilita la organización de un DataFrame según una columna particular o múltiples, siendo organizados de manera ascendente (ascending=True, que es el valor predeterminado) o de forma descendente (ascending=False). En este ejemplo, ascending=True (valor por defecto) es el DataFrame que se clasifica de menor a mayor. Ascending=False es el DataFrame que se organiza de mayor a menor, siendo bastante útil para estudiar y clasificar datos. 
   **Ejemplo:**
 <p align="center">
 <img width="667" height="459" alt="gc13" src="https://github.com/user-attachments/assets/387be993-ca24-43f6-8606-54f9f25f43a0" />
 </p>
 
-- **df[“nueva”]=…** En Pandas, es posible añadir una nueva columna a un DataFrame asignando valores mediante esta expresión la columna que se genere puede ser: una lista o serie que tenga la misma longitud que el DataFrame, un calculo que se base en otras columnas ya presentes o un valor fijo que se aplicara a todas las filas. En este ejemplo, [“constante”]=1 genera una columna donde todas las filas tienen el mismo valor, [“sepal_area”] calcula un área aproximada multiplicando el largo y el ancho del sépalo y [“petal_category”] clasifica cada fila como “Largo” o “Corto” dependiendo el valor de petal_length.       
+- **df[“nueva”]=…:** En Pandas, es posible añadir una nueva columna a un DataFrame asignando valores mediante esta expresión la columna que se genere puede ser: una lista o serie que tenga la misma longitud que el DataFrame, un calculo que se base en otras columnas ya presentes o un valor fijo que se aplicara a todas las filas. En este ejemplo, [“constante”]=1 genera una columna donde todas las filas tienen el mismo valor, [“sepal_area”] calcula un área aproximada multiplicando el largo y el ancho del sépalo y [“petal_category”] clasifica cada fila como “Largo” o “Corto” dependiendo el valor de petal_length.       
   **Ejemplo:**
 <p align="center">
 <img width="686" height="442" alt="gc14" src="https://github.com/user-attachments/assets/f32d30eb-4fa5-4f43-aa74-4b6131e02dc3" />
+</p>
+
+---
+
+## **D) Pandas – Creación y manipulación de DataFrames y Series**
+
+- **df[df[“columna”]>valor]:** Este comando de indexación en Pandas permite seleccionar filas de un DataFrame que satisfacen un criterio lógico ya que, en esencia, se genera una mascara boooleana que escoge exclusivamente los registros que cumplen con los requisitos. En este ejemplo, [“petal_category”] > 5 crea una serie booleana (Verdadero/Falso) que señala que filas cumplen con la condición. […] devuelve solo las filas que son verdaderas. El resultado es un conjunto de flores cuyos pétalos tienen una longitud superior a 5 siendo un tipo de filtrado bastante común en el análisis de subconjuntos de datos.
+  **Ejemplo:**
+<p align="center">
+<img width="653" height="246" alt="cg1" src="https://github.com/user-attachments/assets/89606a27-eff5-4581-8cc3-faba3aae9770" />
+</p>
+
+- **df.grouphy():** Este método se emplea en Pandas para clasificar datos basándose en una o múltiples columnas y posteriormente realizar cálculos estadísticos (como suma, promedio, etc.) sobre estos grupos. Es similar a la clausula GROUP BY en SQL. En este caso, groupby(“Species”) clasifica el Dataframe según la columna de especie para después utilizar mean() para obtener la media de las mediciones de cada grupo, otorgando un resumen con estadísticas por tipo de flor.
+  **Ejemplo:**
+<p align="center">
+<img width="846" height="249" alt="cg2" src="https://github.com/user-attachments/assets/32c8f6bf-b618-4c68-bfad-9ea4cbf8a466" />
+</p>
+ 
+- **pd.merge(df1, df2, on=columna”):** Esta función permite la fusión de dos DataFrames en uno, utilizando una columna en común (llave de unión), resultando similar a las operaciones de INNER JOIN en SQL. En este caso, se combinaron df1 y ddf2 utilizando la columna compartida “id” para que solo se muestren los registros que están presentes en ambos DataFrames (inner join). La persona que tiene id=5 no se incluye porque no se encontraba en df1 y se usa parámetros adicionales como how=”left”, how=”right” o how=”outer”, es posible modificar el tipo de unión.
+  **Ejemplo:**
+<p align="center">
+<img width="416" height="350" alt="cg3" src="https://github.com/user-attachments/assets/1490388e-329d-4068-a6c0-a82a7b5f3f2f" />
+</p>
+
+- **df.dropna():** Este comando se utiliza para quitar las filas (o columnas que presentan valores nulos (NaN) en un DataFrame. Por defecto, se deshace de las filas que están incompletas, pero se pueden incluir parámetros para afectar a columnas o modificar el criterio de supresión. En este ejemplo, dropna() removió todas las filas que tenían al menos un NaN para que solo permaneciera la fila 0 (Ana), dado que era la única fila sin datos faltantes y con el axis=1 se pueden eliminar columnas que contengan valores nulos, y al utilizar how=”all” solo se eliminan si toda la fila o columna es nula. 
+  **Ejemplo:**
+<p align="center">
+<img width="399" height="473" alt="cg4" src="https://github.com/user-attachments/assets/c6e48f8f-3bb8-47b2-8dd4-fc887aece0b9" />
+</p>
+
+- **df.fillna(valor):** Este método se emplea para sustituir los valores que son nulos (NaN) en un DataFrame por un valor determinado o mediante técnicas como la media, la mediana o valores de o los valores de otras filas. A diferencias de dropna(), este método no elimina datos, sino que los sustituye para conservar la organización del DataFrame. En este caso, los valores nulos en “nombre” fueron sustituidos por “Desconocido”, los valores nulos en “edad” fueron reemplazados por 0 y los valores nulos en “nota” fueron modificados con la media de la columna, que es 87.6. 
+  **Ejemplo:**
+<p align="center">
+<img width="662" height="477" alt="cg5" src="https://github.com/user-attachments/assets/a941081b-f09d-4dad-a6e6-ae442719dba9" />
+</p>
+
+- **df.to_csv(“archivo.csv”, index=False):** El método to_csv() se emplea para transferir un DataFrame a un archivo en formato CSV (valores separados por comas), este formato es comúnmente utilizado para guardar y distribuir información. El parámetro Index=False señala que no deseamos incorporar la columna de índice en el archivo exportado (dado que generalmente no es requerida). Con esto, podemos almacenar nuestros DataFrames y utilizarlos en otros programas, compartirlos o analizarlos mediante Excel, Google sheets, etc. 
+  **Ejemplo:**
+<p align="center">
+<img width="659" height="364" alt="cg6" src="https://github.com/user-attachments/assets/fc4eee0a-0bf0-4728-bdcf-06a59c4bc2a5" />
 </p>


### PR DESCRIPTION
Se agregan comandos para las operaciones avanzadas presentes en la librería Pandas junto a sus respectivos ejemplos en Google Colab:
-df[df[“columna”]>valor]
-df.grouphy()
-pd.merge(df1, df2, on=columna”)
-df.dropna()
-df.fillna(valor)
-df.to_csv(“archivo.csv”, index=False)
-df.isnull()
-df.isnull()sum(
-df.join(df2)
-pd.concat([df1, df2])
-df.drop_duplicates()
-df.rename(colums={"old":"new"})
-df.to_excel(“archivo.xlsx”, index=false)

Fuentes Bibliográficas:
-Moya, R. (2015, 30 de octubre). Pandas en Python, con ejemplos – Parte II – Lectura-Escritura, Merge & GroupBy. Jarroba. Recuperado de https://jarroba.com/pandas-python-ejemplos-parte-ii-io-merge-groupby/
-López B., L. (2020, octubre). Guía práctica para análisis exploratorio de datos con Pandas. Medium. Recuperado de https://lauralpezb.medium.com/gu%C3%ADa-practica-para-an%C3%A1lisis-exploratorio-de-datos-con-pandas-565f09a187ab